### PR TITLE
Delete Println method from GenericLogger interface

### DIFF
--- a/akamai/errors.go
+++ b/akamai/errors.go
@@ -46,7 +46,6 @@ func (error APIError) Error() string {
 // or http.Response-like.
 func NewAPIError(response *http.Response) *APIError {
 	body, _ := ioutil.ReadAll(response.Body)
-	fmt.Println(string(body))
 	return NewAPIErrorFromBody(response, body)
 }
 

--- a/akamai/internal/logger/logger.go
+++ b/akamai/internal/logger/logger.go
@@ -10,7 +10,6 @@ type GenericLogger interface {
 	Warnf(format string, args ...interface{})
 	Error(args ...interface{})
 	Errorf(format string, args ...interface{})
-	Println(v ...interface{})
 }
 
 // VoidLogger represents nil implementation of GenericLogger.
@@ -39,9 +38,6 @@ func (l *VoidLogger) Error(args ...interface{}) {}
 
 // Errorf void implementation.
 func (l *VoidLogger) Errorf(format string, args ...interface{}) {}
-
-// Println void implementation.
-func (l VoidLogger) Println(v ...interface{}) {}
 
 // SelectLogger returns one logger from given.
 func SelectLogger(logger ...GenericLogger) GenericLogger {


### PR DESCRIPTION
For the sake of better capability with different third-party loggers.